### PR TITLE
Fix #87 pow negative number

### DIFF
--- a/src/main/java/org/swrlapi/builtins/swrlb/SWRLBuiltInLibraryImpl.java
+++ b/src/main/java/org/swrlapi/builtins/swrlb/SWRLBuiltInLibraryImpl.java
@@ -1524,7 +1524,7 @@ public class SWRLBuiltInLibraryImpl extends AbstractSWRLBuiltInLibrary
     } else if (builtInName.equalsIgnoreCase(SWRLB_POW)) {
       int argument3 = convertArgumentToAnInt(2, arguments);
       BigDecimal argument2 = getArgumentAsADecimal(1, arguments);
-      operationResult = argument2.pow(argument3);
+      operationResult = argument2.pow(argument3, mathContext);
     } else if (builtInName.equalsIgnoreCase(SWRLB_UNARY_PLUS)) {
       BigDecimal argument2 = getArgumentAsADecimal(1, arguments);
       operationResult = argument2;


### PR DESCRIPTION
  Add a mathcontext to swrlb:pow

  Mathcontext is required to allow the use of
  negative values as second argument for a pow
  operation with `BigDecimal`.

  Fixes #87